### PR TITLE
use numerical ids to index the proxified objects store

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -114,6 +114,12 @@ export class PyObject {
   static fromJS: (v: any) => PyObject;
 
   /**
+   * Numeric id of the object, it is generally the same as the one returned by id()
+   * @type {number}
+   */
+  readonly id: number;
+
+  /**
    * Is the property callable
    * @type {boolean}
    */

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const proxyStore = new WeakMap();
 
 function proxify(v, name) {
   if (v instanceof module.exports.PyObject) {
-    let r = proxyStore[v];
+    let r = proxyStore[v.id];
     if (r !== undefined) return r;
     if (v.callable) {
       r = (...args) => {
@@ -25,7 +25,7 @@ function proxify(v, name) {
     if (name !== undefined) {
       Object.defineProperty(r, 'name', { value: name, writable: false });
     }
-    proxyStore[v] = r;
+    proxyStore[v.id] = r;
     return r;
   }
   return v;

--- a/src/pymport.h
+++ b/src/pymport.h
@@ -62,6 +62,7 @@ class PyObjectWrap : public Napi::ObjectWrap<PyObjectWrap> {
 
   Napi::Value ToString(const Napi::CallbackInfo &);
 
+  Napi::Value Id(const Napi::CallbackInfo &);
   Napi::Value Get(const Napi::CallbackInfo &);
   Napi::Value Call(const Napi::CallbackInfo &);
   Napi::Value Item(const Napi::CallbackInfo &);

--- a/src/pyobj.cc
+++ b/src/pyobj.cc
@@ -45,6 +45,7 @@ Function PyObjectWrap::GetClass(Napi::Env env) {
      PyObjectWrap::InstanceMethod("call", &PyObjectWrap::Call),
      PyObjectWrap::InstanceMethod("toJS", &PyObjectWrap::ToJS),
      PyObjectWrap::InstanceMethod("valueOf", &PyObjectWrap::ToJS),
+     PyObjectWrap::InstanceAccessor("id", &PyObjectWrap::Id, nullptr),
      PyObjectWrap::InstanceAccessor("type", &PyObjectWrap::Type, nullptr),
      PyObjectWrap::InstanceAccessor("callable", &PyObjectWrap::Callable, nullptr),
      PyObjectWrap::InstanceAccessor("length", &PyObjectWrap::Length, nullptr),
@@ -71,6 +72,12 @@ Value PyObjectWrap::ToString(const CallbackInfo &info) {
   PyStrongRef r = PyObject_Str(*self);
   EXCEPTION_CHECK(env, r);
   return ToJS(env, r);
+}
+
+Value PyObjectWrap::Id(const CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  return Number::New(env, reinterpret_cast<uint64_t>(*self));
 }
 
 Value PyObjectWrap::Get(const CallbackInfo &info) {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -120,4 +120,12 @@ describe('proxy', () => {
     const dict = proxify(PyObject.dict({ a: 0, b: 1 }));
     assert.deepEqual(PyObject.values(dict).toJS(), [0, 1]);
   });
+
+  it('does not mismatch objects with identical string representation', () => {
+    const obj1 = proxify(PyObject.fromJS({ a: 1 }));
+    const obj2 = proxify(PyObject.fromJS({ a: 1 }));
+
+    assert.deepEqual(obj1.toJS(), obj2.toJS());
+    assert.notEqual(obj1, obj2);
+  });
 });


### PR DESCRIPTION
Fix #4, a very severe bug (random data corruption) in the proxified object store