### PR TITLE
Do not cache getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] WIP
 
+#### New Features
 - Converting JS functions to Python callables
 - Expiring of function objects
 - Converting of `bytes` and `bytearray` to `Buffer` and `Buffer` to `bytearray`
@@ -20,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore the last argument of a Python function call if it is `undefined` - this allows to pass a last argument as a dictionary by calling `fn(obj, undefined)` instead of `fn(obj)` which will transform `obj` into named kw arguments
 - Support `PyObject.keys` and `PyObject.values` on `profixy`ed objects
 - (internals) New automatic reference counting
+
+#### Bug Fixes
+- Fix [[#6](https://github.com/mmomtchev/pymport/issues/6)], proxified objects are wrongly caching values returned by getters
 
 ### [1.0.1] 2022-10-29
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,7 @@ const proxy = {
           return proxify(result);
         };
         Object.defineProperty(r, 'name', { value: prop, writable: false });
+        target.__pymport_proxy__[prop] = r;
       } else {
         // Create a profixied object for the PyObject value
         r = proxify(target[prop]);
@@ -67,8 +68,7 @@ const proxy = {
       return undefined;
     }
 
-    target.__pymport_proxy__[prop] = r;
-    return target.__pymport_proxy__[prop];
+    return r;
   }
 };
 

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -128,4 +128,14 @@ describe('proxy', () => {
     assert.deepEqual(obj1.toJS(), obj2.toJS());
     assert.notEqual(obj1, obj2);
   });
+
+  describe('list', () => {
+    it('append()', () => {
+      const list = proxify(PyObject.list([1]));
+      assert.lengthOf(list, 1);
+      list.append(2);
+      assert.deepEqual(list.toJS(), [1, 2]);
+      assert.lengthOf(list, 2);
+    });
+  });
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -129,6 +129,15 @@ describe('types', () => {
       assert.deepEqual(a.toJS(), array);
     });
 
+    it('append()', () => {
+      const a = PyObject.list([1]);
+      assert.lengthOf(a, 1);
+      a.get('append').call(2);
+      assert.equal(a.type, 'list');
+      assert.deepEqual(a.toJS(), [1, 2]);
+      assert.lengthOf(a, 2);
+    });
+
     it('throws on invalid value', () => {
       assert.throws(() => PyObject.list({ b: 12 } as unknown as number[]), /Argument must be/);
     });


### PR DESCRIPTION
Only proxified functions should be cached in `__pymport_proxy__`, objects returned by getters will be cached by the general store