### PR TITLE
Correctly detect and test `Infinity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (internals) New automatic reference counting
 
 #### Bug Fixes
-- Fix [[#6](https://github.com/mmomtchev/pymport/issues/6)], proxified objects are wrongly caching values returned by getters
+- Fix [#6](https://github.com/mmomtchev/pymport/issues/6), proxified objects are wrongly caching values returned by getters
+- Fix [#8](https://github.com/mmomtchev/pymport/issues/8), `Infinity` is not recognized as a float by the automatic conversion
 
 ### [1.0.1] 2022-10-29
 

--- a/src/fromjs.cc
+++ b/src/fromjs.cc
@@ -1,4 +1,4 @@
-#include <math.h>
+#include <cmath>
 #include "pymport.h"
 #include "pystackobject.h"
 #include "values.h"

--- a/src/fromjs.cc
+++ b/src/fromjs.cc
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "pymport.h"
 #include "pystackobject.h"
 #include "values.h"

--- a/src/fromjs.cc
+++ b/src/fromjs.cc
@@ -195,7 +195,9 @@ PyStrongRef PyObjectWrap::_FromJS(Napi::Value v, PyObjectStore &store) {
     double integer;
     double fract = fabs(modf(raw, &integer));
     PyStrongRef py = nullptr;
-    if (fract < std::numeric_limits<float>::epsilon() || fract > 1 - std::numeric_limits<float>::epsilon())
+    if (
+      (fract < std::numeric_limits<float>::epsilon() || fract > 1 - std::numeric_limits<float>::epsilon()) &&
+      !std::isinf(raw))
       py = PyLong_FromLongLong(static_cast<long long>(v.ToNumber().Int64Value()));
     else
       py = PyFloat_FromDouble(raw);

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -40,6 +40,25 @@ describe('types', () => {
     it('throws on invalid value', () => {
       assert.throws(() => PyObject.float('a' as unknown as number), /Argument must be/);
     });
+
+    it('nan', () => {
+      const f = PyObject.fromJS(NaN);
+      assert.equal(f.type, 'float');
+      assert.deepEqual(f.toString(), 'nan');
+      assert.isNaN(f.toJS());
+    });
+
+    it('inf', () => {
+      const pf = PyObject.fromJS(Infinity);
+      assert.equal(pf.type, 'float');
+      assert.deepEqual(pf.toString(), 'inf');
+      assert.equal(pf.toJS(), Infinity);
+
+      const nf = PyObject.fromJS(-Infinity);
+      assert.equal(nf.type, 'float');
+      assert.deepEqual(nf.toString(), '-inf');
+      assert.equal(nf.toJS(), -Infinity);
+    });
   });
 
   describe('int', () => {


### PR DESCRIPTION
`Infinity` should be detected as a `float` when doing automatic conversion