### PR TITLE
support setting `PYTHONHOME`

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -83,6 +83,66 @@ jobs:
       - run: pip3 install -r test/requirements.txt
       - run: npm test
 
+  external_python_wo_rebuild_posix:
+    runs-on: ${{ matrix.platform }}
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-11]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: npm install --ignore-scripts
+      - run: npx @mapbox/node-pre-gyp configure --builtin_python
+      - run: npx @mapbox/node-pre-gyp build -j max
+      - run: python3 -m pip install --upgrade pip
+      - run: pip3 install -r test/requirements.txt
+      - name: Find system Python
+        run: echo PYTHONHOME=$(python -c "import sys; print(sys.prefix)") >> $GITHUB_ENV
+      - name: Test PYTHONOME
+        run: echo READ_PYTHONHOME=$(node -e "console.log(require('pymport').version.pythonHome)") >> $GITHUB_ENV
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: ${{ env.PYTHONHOME }}
+          actual: ${{ env.READ_PYTHONHOME }}
+          comparison: exact
+      - run: npm test
+
+  external_python_wo_rebuild_win:
+    runs-on: windows-2019
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: npm install --ignore-scripts
+      - run: npx @mapbox/node-pre-gyp configure --builtin_python
+      - run: npx @mapbox/node-pre-gyp build -j max
+      - run: python3 -m pip install --upgrade pip
+      - run: pip3 install -r test/requirements.txt
+      - name: Find system Python
+        run: echo PYTHONHOME=$(python -c "import sys; print(sys.prefix)") >> $env:GITHUB_ENV
+      - name: Test PYTHONOME
+        run: echo READ_PYTHONHOME=$(node -e "console.log(require('pymport').version.pythonHome)") >> $env:GITHUB_ENV
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: ${{ env.PYTHONHOME }}
+          actual: ${{ env.READ_PYTHONHOME }}
+          comparison: exact
+      - run: npm test
+
   debug_build:
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -114,7 +114,8 @@ jobs:
           actual: ${{ env.READ_PYTHONHOME }}
           comparison: exact
       - run: npm test
-        env: MOCHA_SKIP_VERSION_CHECK: 1
+        env:
+          MOCHA_SKIP_VERSION_CHECK: 1
 
   external_python_wo_rebuild_win:
     runs-on: windows-2019

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -114,6 +114,7 @@ jobs:
           actual: ${{ env.READ_PYTHONHOME }}
           comparison: exact
       - run: npm test
+        env: MOCHA_SKIP_VERSION_CHECK=1
 
   external_python_wo_rebuild_win:
     runs-on: windows-2019
@@ -134,7 +135,7 @@ jobs:
       - run: pip3 install -r test/requirements.txt
       - name: Find system Python
         run: echo PYTHONHOME=$(python -c "import sys; print(sys.prefix)") >> $env:GITHUB_ENV
-      - name: Test PYTHONOME
+      - name: Test PYTHONHOME
         run: echo READ_PYTHONHOME=$(node -e "console.log(require('pymport').version.pythonHome)") >> $env:GITHUB_ENV
       - uses: nick-fields/assert-action@v1
         with:

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -114,7 +114,7 @@ jobs:
           actual: ${{ env.READ_PYTHONHOME }}
           comparison: exact
       - run: npm test
-        env: MOCHA_SKIP_VERSION_CHECK=1
+        env: MOCHA_SKIP_VERSION_CHECK: 1
 
   external_python_wo_rebuild_win:
     runs-on: windows-2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1] WIP
 - Fix [#14](https://github.com/mmomtchev/pymport/issues/14), `toJS()` converts Python `bool` to JS `number`
 - Restore the JS function when converting a `pymport.js_function` back to JS
-- Fix [#17](https://github.com/mmomtchev/pymport/issues/17), `PYTHONHOME` is ignored 
+- Fix [#17](https://github.com/mmomtchev/pymport/issues/17), `PYTHONHOME` is ignored
+- In the version reporting, replace the `"undefined"` suffix with a `""` when there is no version suffix
 
 ## [1.1.0] 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1] WIP
 - Fix [#14](https://github.com/mmomtchev/pymport/issues/14), `toJS()` converts Python `bool` to JS `number`
 - Restore the JS function when converting a `pymport.js_function` back to JS
+- Fix [#17](https://github.com/mmomtchev/pymport/issues/17), `PYTHONHOME` is ignored 
 
 ## [1.1.0] 2022-11-08
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
         'PYMPORT_VERSION_MAJOR=<!(node -e "console.log(require(\'./package.json\').version.split(\'.\')[0])")',
         'PYMPORT_VERSION_MINOR=<!(node -e "console.log(require(\'./package.json\').version.split(\'.\')[1])")',
         'PYMPORT_VERSION_PATCH=<!(node -e "console.log(require(\'./package.json\').version.split(\'-\')[0].split(\'.\')[2])")',
-        'PYMPORT_VERSION_SUFFIX=<!(node -e "console.log(require(\'./package.json\').version.split(\'-\')[1])")'
+        'PYMPORT_VERSION_SUFFIX=<!(node -e "console.log(require(\'./package.json\').version.split(\'-\')[1] || \'\')")'
       ],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'conditions': [

--- a/src/main.cc
+++ b/src/main.cc
@@ -34,7 +34,7 @@ Value Version(const CallbackInfo &info) {
   pymportVersion.Set("major", Number::New(env, PYMPORT_VERSION_MAJOR));
   pymportVersion.Set("minor", Number::New(env, PYMPORT_VERSION_MINOR));
   pymportVersion.Set("patch", Number::New(env, PYMPORT_VERSION_PATCH));
-  pymportVersion.Set("suffix", String::New(env, STR(PYMPORT_VERSION_SUFFIX)));
+  pymportVersion.Set("suffix", String::New(env, STR("" PYMPORT_VERSION_SUFFIX)));
 
 #ifdef BUILTIN_PYTHON_PATH
   bool builtin = true;

--- a/src/main.cc
+++ b/src/main.cc
@@ -101,12 +101,15 @@ Napi::Object Init(Env env, Object exports) {
   if (active_environments == 0) {
 #ifdef BUILTIN_PYTHON_PATH
     auto pathPymport = std::getenv("PYMPORTPATH");
-    if (pathPymport == nullptr) {
-      Py_SetPythonHome(BUILTIN_PYTHON_PATH);
-    } else {
-      std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-      builtin_python_path = converter.from_bytes(pathPymport);
-      Py_SetPythonHome(builtin_python_path.c_str());
+    auto homePython = std::getenv("PYTHONHOME");
+    if (homePython == nullptr) {
+      if (pathPymport == nullptr) {
+        Py_SetPythonHome(BUILTIN_PYTHON_PATH);
+      } else {
+        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+        builtin_python_path = converter.from_bytes(pathPymport);
+        Py_SetPythonHome(builtin_python_path.c_str());
+      }
     }
 #endif
     Py_Initialize();

--- a/test/pymport.test.ts
+++ b/test/pymport.test.ts
@@ -2,7 +2,9 @@ import { pymport, PyObject, PythonError, version } from 'pymport';
 import { assert } from 'chai';
 
 describe('pymport', () => {
-  it('version', () => {
+  it('version', function () {
+    if (process.env['MOCHA_SKIP_VERSION_CHECK']) this.skip();
+
     assert.isNumber(version.pymport.major);
     assert.isNumber(version.pymport.minor);
     assert.isNumber(version.pymport.patch);


### PR DESCRIPTION
Allow to set `PYTHONHOME` to another installation when using the builtin Python.

This remains a very dangerous option since there is no way to ensure that this Python installation will be compatible with the builtin library.