### PR TITLE
native function arguments in JS callbacks of Python code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] WIP
+ - (***BREAKING***) Conversion of arguments in JS callbacks of Python code is now automatic only if it can be correctly deduced from the context, `toJS()` must be called in all other cases
+
 ## [1.1.1] 2022-11-11
 - Fix [#14](https://github.com/mmomtchev/pymport/issues/14), `toJS()` converts Python `bool` to JS `number`
 - Restore the JS function when converting a `pymport.js_function` back to JS

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ As a last step, you should probably check the [`graph-tool` example](https://git
 
 Since 1.1 functions can be freely passed between Python and JavaScript.
 
-All arguments will be automatically converted when possible.
+As when calling Python functions, argument conversion from JavaScript to Python is always automatic. Conversion from Python to JavaScript is automatic only when it can be deduced from the context (in `a + 1`, `a` will be converted to `number`) according to the rules governing `Symbol.toPrimitive`. In all other cases, `toJS()` must be called.
 
 If JavaScript calls a Python function with an unsupported type (`Symbol` for example), the call will throw.
 
@@ -263,7 +263,7 @@ All three of those can also be used as a Python object to be passed as an argume
 
 If the Python function throws, JavaScript will receive a normal JavaScript `Error` object containing the Python error message prefixed with `Python exception`. This object will be extended with an additional attribute, `pythonTrace` which will be a `PyObject` containing the Python traceback.
 
-When passing a JavaScript function to Python, the resulting object has a special Python type `pymport.js_function`, that cannot be constructed in any other way. It is a Python callable that is otherwise indistinguishable from a Python function. If Python calls this function with an unsupported argument type, the JavaScript function will receive a `PyObject` for this argument. If the JavaScript function throws, Python will receive a generic `Exception` object containing the JavaScript error message. If Python does not handle this error, the error will eventually propagate back to the calling JavaScript code where it will be a JavaScript `Error` object containing a `pythonTrace` with the Python part of the stack.
+When passing a JavaScript function to Python, the resulting object has a special Python type `pymport.js_function`, that cannot be constructed in any other way. It is a Python callable that is otherwise indistinguishable from a Python function. If the JavaScript function throws, Python will receive a generic `Exception` object containing the JavaScript error message. If Python does not handle this error, the error will eventually propagate back to the calling JavaScript code where it will be a JavaScript `Error` object containing a `pythonTrace` with the Python part of the stack.
 
 ### Importing user modules from the current directory
 

--- a/test/pymport.test.ts
+++ b/test/pymport.test.ts
@@ -56,6 +56,15 @@ describe('pymport', () => {
       }
       assert.deepEqual(result, [0, 1, 2, 3, 4, 5]);
     });
+
+    it('fromfunction()', () => {
+      const np = pymport('numpy');
+      const fn = (x: PyObject, y: PyObject) => {
+        return x.get('__add__').call(y);
+      };
+      const a = np.get('fromfunction').call(fn, [2, 3]);
+      assert.deepEqual(a.get('tolist').call().toJS(), [[0, 1, 2], [1, 2, 3]]);
+    });
   });
 
   describe('pandas', () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -471,7 +471,10 @@ describe('types', () => {
     });
 
     it('constructor', () => {
-      const fn = PyObject.func((a: any) => a + 2);
+      const fn = PyObject.func((a: any) => {
+        assert.instanceOf(a, PyObject);
+        return a + 2;
+      });
 
       assert.instanceOf(fn, PyObject);
       assert.isTrue(fn.callable);


### PR DESCRIPTION
Handling of arguments of JS callbacks of Python code now follows the same rules as handling the return value of Python functions in JS