### PR TITLE
run the builtin Python from `bin`

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -167,7 +167,7 @@
               'action': [
                 'install_name_tool', '-change',
                 '<(module_path)/lib/libpython3.11.dylib',
-                '@loader_path/lib/libpython3.11.dylib',
+                '@loader_path/../lib/libpython3.11.dylib',
                 '<(module_path)/bin/python3.11'
               ]
             }

--- a/scripts/pympip
+++ b/scripts/pympip
@@ -5,8 +5,8 @@ const cp = require('child_process');
 const os = require('os');
 
 const bin_dir = path.resolve(path.dirname(
-  require('@mapbox/node-pre-gyp').find(path.join(__dirname, '..', 'package.json'))));
-const exe = os.platform() === 'win32' ? 'python.exe' : 'python';
+  require('@mapbox/node-pre-gyp').find(path.join(__dirname, '..', 'package.json'))), 'bin');
+const exe = os.platform() === 'win32' ? 'python.exe' : 'python3';
 const python = path.join(bin_dir, exe);
 if (fs.existsSync(python)) {
   cp.spawnSync(python, ['-m', 'pip', ...process.argv.slice(2)], { stdio: 'inherit', env: { PYTHONHOME: bin_dir } });

--- a/scripts/pympip
+++ b/scripts/pympip
@@ -5,8 +5,8 @@ const cp = require('child_process');
 const os = require('os');
 
 const bin_dir = path.resolve(path.dirname(
-  require('@mapbox/node-pre-gyp').find(path.join(__dirname, '..', 'package.json'))), 'bin');
-const exe = os.platform() === 'win32' ? 'python.exe' : 'python3';
+  require('@mapbox/node-pre-gyp').find(path.join(__dirname, '..', 'package.json'))));
+const exe = os.platform() === 'win32' ? 'python.exe' : path.join('bin', 'python3');
 const python = path.join(bin_dir, exe);
 if (fs.existsSync(python)) {
   cp.spawnSync(python, ['-m', 'pip', ...process.argv.slice(2)], { stdio: 'inherit', env: { PYTHONHOME: bin_dir } });


### PR DESCRIPTION
Avoid ambiguity on macOS 12 where `@loader_path` resolves from the symlinked target