### PR TITLE
revert to Python 3.10

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         platform: [ubuntu-20.04, ubuntu-22.04, macos-11, windows-2019]
         node-version: [16.x, 18.x, 19.x]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.10"]
         exclude:
           - node-version: 16.x
             platform: ubuntu-22.04
@@ -58,6 +58,8 @@ jobs:
       - run: node ./scripts/pympip install --upgrade pip
       - run: node ./scripts/pympip install -r test/requirements.txt
       - run: npm test
+      - run: |
+          node ./scripts/pympip install --no-binary :all: xxhash
 
   external_python:
     runs-on: ${{ matrix.platform }}
@@ -74,7 +76,7 @@ jobs:
           node-version: 18.x
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: set LIBS
         run: echo LIBS=`pkg-config --libs python3-embed` >> $GITHUB_ENV
       - name: set CXXFLAGS
@@ -101,7 +103,7 @@ jobs:
           node-version: 18.x
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: npm install --ignore-scripts
       - run: npx @mapbox/node-pre-gyp configure --builtin_python
       - run: npx @mapbox/node-pre-gyp build -j max
@@ -131,7 +133,7 @@ jobs:
           node-version: 18.x
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: npm install --ignore-scripts
       - run: npx @mapbox/node-pre-gyp configure --builtin_python
       - run: npx @mapbox/node-pre-gyp build -j max
@@ -163,7 +165,7 @@ jobs:
           node-version: 18.x
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: npm install --ignore-scripts
       - run: npx @mapbox/node-pre-gyp configure --debug
       - run: npx @mapbox/node-pre-gyp build -j max

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,7 +21,7 @@ jobs:
           - macos-11
           - macos-12
         node-version: [14.x, 16.x, 18.x, 19.x]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.10"]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
@@ -58,10 +58,10 @@ jobs:
       matrix:
         platform: [ubuntu-20.04, ubuntu-22.04, windows-2019, macos-11]
         node-version: [14.x, 16.x, 18.x, 19.x]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.10"]
         exclude:
           - node-version: 14.x
-            python-version: "3.11"
+            python-version: "3.10"
           - node-version: 14.x
             platform: ubuntu-22.04
           - node-version: 16.x
@@ -109,7 +109,7 @@ jobs:
           node-version: 18.x
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: set LIBS
         run: echo LIBS=`pkg-config --libs python3-embed` >> $GITHUB_ENV
       - name: set CXXFLAGS

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-11
           - macos-12
         node-version: [14.x, 16.x, 18.x, 19.x]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -58,7 +58,7 @@
       "name": "Windows",
       "includePath": [
         "${workspaceFolder}/node_modules/node-addon-api",
-        "C:/Program Files/Python311/include",
+        "C:/Program Files/Python310/include",
         "~/AppData/Local/node-gyp/Cache/16.10.0/include/node"
       ],
       "defines": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] WIP
 
 #### New Features
- - Builtin Python 3.11.1
+ - Builtin Python 3.10.9
  - Multithreading safety
  - `callAsync` method allowing asynchronous calling of Python functions
  - On Linux and macOS, the builtin Python interpreter includes static versions of OpenSSL and libffi, this ensures better compatiblity at the price of disabling the OpenSSL extensions supporting dedicated crypto hardware - this restriction does not apply if `pymport` is rebuilt from source

--- a/binding.gyp
+++ b/binding.gyp
@@ -66,7 +66,7 @@
             }],
             ['builtin_python == "true"', {
               'dependencies': [ 'builtin_python' ],
-              'include_dirs': [ 'build\Python-3.11.1\Include', 'build\Python-3.11.1\PC' ],
+              'include_dirs': [ 'build\Python-3.10.9\Include', 'build\Python-3.10.9\PC' ],
               'msvs_settings': {
                 'VCLinkerTool': {
                   'AdditionalLibraryDirectories': '<(module_path)'
@@ -88,8 +88,8 @@
             }],
             ['builtin_python == "true"', {
               'dependencies': [ 'builtin_python' ],
-              'include_dirs': [ '<(module_path)/include/python3.11' ],
-              'libraries': [ '-L<(module_path)/lib/ -lpython3.11' ],
+              'include_dirs': [ '<(module_path)/include/python3.10' ],
+              'libraries': [ '-L<(module_path)/lib/ -lpython3.10' ],
               'ldflags': [ '-Wl,-z,origin', '-Wl,-rpath,\'$$ORIGIN/lib\'' ]
             }]
           ],
@@ -127,7 +127,7 @@
         'actions': [{
           'action_name': 'Python',
           'inputs': [ './build_python.sh' ],
-          'outputs': [ '<(module_path)/lib/libpython3.11.so' ],
+          'outputs': [ '<(module_path)/lib/libpython3.10.so' ],
           'action': [ 'sh', 'build_python.sh', '<(module_path)' ]
         }]
       }]
@@ -140,7 +140,7 @@
           'actions': [{
             'action_name': 'Python',
             'inputs': [ './build_python.sh' ],
-            'outputs': [ '<(module_path)/lib/libpython3.11.dylib' ],
+            'outputs': [ '<(module_path)/lib/libpython3.10.dylib' ],
             'action': [ 'sh', 'build_python.sh', '<(module_path)' ]
           }]
         },
@@ -150,13 +150,13 @@
           'dependencies': [ 'action_after_build' ],
           'actions': [
             {
-              'action_name': 'install_name_tool_libpython3.11.dylib',
+              'action_name': 'install_name_tool_libpython3.10.dylib',
               'inputs': [ '<(module_path)/pymport.node' ],
               'outputs': [ '<(module_path)/.install_name_tool_dylib' ],
               'action': [
                 'install_name_tool', '-change',
-                '<(module_path)/lib/libpython3.11.dylib',
-                '@loader_path/lib/libpython3.11.dylib',
+                '<(module_path)/lib/libpython3.10.dylib',
+                '@loader_path/lib/libpython3.10.dylib',
                 '<(module_path)/pymport.node'
               ]
             },
@@ -166,9 +166,9 @@
               'outputs': [ '<(module_path)/.install_name_tool_exe' ],
               'action': [
                 'install_name_tool', '-change',
-                '<(module_path)/lib/libpython3.11.dylib',
-                '@loader_path/../lib/libpython3.11.dylib',
-                '<(module_path)/bin/python3.11'
+                '<(module_path)/lib/libpython3.10.dylib',
+                '@loader_path/../lib/libpython3.10.dylib',
+                '<(module_path)/bin/python3.10'
               ]
             }
           ]
@@ -182,7 +182,7 @@
         'actions': [{
           'action_name': 'Python',
           'inputs': [ './build_python.bat' ],
-          'outputs': [ '<(module_path)/Python311.lib', '<(module_root_dir)/build/Python-3.11.1/Include/Python.h' ],
+          'outputs': [ '<(module_path)/Python310.lib', '<(module_root_dir)/build/Python-3.10.9/Include/Python.h' ],
           'action': [ '<(module_root_dir)/build_python.bat', '<(module_path)' ]
         }]
       }]

--- a/build_python.bat
+++ b/build_python.bat
@@ -16,6 +16,7 @@ if not exist "%1\python311.lib" (
   build\Python-%VERSION%\PCBuild\build.bat
   (robocopy build\Python-%VERSION%\PCBuild\amd64 %1 /MIR) ^& if %ERRORLEVEL% leq 1 set ERRORLEVEL = 0
   (robocopy build\Python-%VERSION%\Lib %1\lib /MIR) ^& if %ERRORLEVEL% leq 1 set ERRORLEVEL = 0
+  (robocopy build\Python-%VERSION%\Include %1\include /MIR) ^& if %ERRORLEVEL% leq 1 set ERRORLEVEL = 0
   set PYTHONHOME=%~1
   %1\python -m ensurepip
 )

--- a/build_python.bat
+++ b/build_python.bat
@@ -1,4 +1,4 @@
-set VERSION=3.11.1
+set VERSION=3.10.9
 
 set mypath=%~dp0
 cd %mypath:~0,-1%
@@ -8,7 +8,7 @@ if not exist dist\Python-%VERSION%.tgz (
   curl https://www.python.org/ftp/python/%VERSION%/Python-%VERSION%.tgz --output dist\Python-%VERSION%.tgz
 )
 
-if not exist "%1\python311.lib" (
+if not exist "%1\python310.lib" (
   echo building in %1
   rd /q /s build\Python-%VERSION%
 

--- a/build_python.sh
+++ b/build_python.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=3.11.1
+VERSION=3.10.9
 
 set -x
 unset MAKEFLAGS
@@ -24,9 +24,9 @@ if [ ! -d "$1" ] || [ ! -r "${LIBNAME}" ]; then
       'Linux')
         export LDFLAGS="-Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN/../lib'"
         export CFLAGS=""
-        LIBNAME="$1/lib/libpython3.11.so"
+        LIBNAME="$1/lib/libpython3.10.so"
         export ZLIB_LIBS="-lz -ldl"
-        patch < ../../patches/python-3.11-setup.py.patch
+        patch < ../../patches/python-3.10-setup.py.patch
         ;;
       'Darwin')
         export LDFLAGS="-Wl,-rpath,@loader_path/../lib"
@@ -35,8 +35,8 @@ if [ ! -d "$1" ] || [ ! -r "${LIBNAME}" ]; then
         cp $(brew --prefix openssl@1.1)/lib/*.a ../openssl/lib
         cp -r $(brew --prefix openssl@1.1)/include/openssl ../openssl/include
         export SSL="--with-openssl=$(pwd)/../openssl"
-        LIBNAME="$1/lib/libpython3.11.dylib"
-        patch < ../../patches/python-3.11-configure.patch
+        LIBNAME="$1/lib/libpython3.10.dylib"
+        patch < ../../patches/python-3.10-configure.patch
         ;;
       *)
         echo 'Unsupported platform for the builtin Python interpreter'

--- a/build_python.sh
+++ b/build_python.sh
@@ -20,13 +20,14 @@ if [ ! -d "$1" ] || [ ! -r "${LIBNAME}" ]; then
     cd build/Python-${VERSION}
 
     export PY_UNSUPPORTED_OPENSSL_BUILD=static
+    patch < ../../patches/python-3.10-setup.py.patch
+    patch < ../../patches/python-3.10-configure.patch
     case `uname` in
       'Linux')
         export LDFLAGS="-Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN/../lib'"
         export CFLAGS=""
         LIBNAME="$1/lib/libpython3.10.so"
         export ZLIB_LIBS="-lz -ldl"
-        patch < ../../patches/python-3.10-setup.py.patch
         ;;
       'Darwin')
         export LDFLAGS="-Wl,-rpath,@loader_path/../lib"
@@ -36,7 +37,6 @@ if [ ! -d "$1" ] || [ ! -r "${LIBNAME}" ]; then
         cp -r $(brew --prefix openssl@1.1)/include/openssl ../openssl/include
         export SSL="--with-openssl=$(pwd)/../openssl"
         LIBNAME="$1/lib/libpython3.10.dylib"
-        patch < ../../patches/python-3.10-configure.patch
         ;;
       *)
         echo 'Unsupported platform for the builtin Python interpreter'

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -331,7 +331,7 @@ declare const version: {
   };
   readonly pythonHome: string;
   /**
-   * Supported only on Python 3.11+
+   * Supported only on Python 3.10+
    */
   readonly pythonRuntime: null | string;
 };

--- a/patches/python-3.10-configure.patch
+++ b/patches/python-3.10-configure.patch
@@ -1,0 +1,54 @@
+--- configure.orig	2022-12-16 13:18:32.859905065 +0100
++++ configure	2022-12-16 13:23:03.467754104 +0100
+@@ -17845,6 +17845,51 @@
+ $as_echo "$OPENSSL_RPATH" >&6; }
+ 
+ 
++# This static linking is NOT OFFICIALLY SUPPORTED and not advertised.
++# Requires static OpenSSL build with position-independent code. Some features
++# like DSO engines or external OSSL providers don't work. Only tested with GCC
++# and clang on X86_64.
++if test "x$PY_UNSUPPORTED_OPENSSL_BUILD" = xstatic; then :
++
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unsupported static openssl build" >&5
++$as_echo_n "checking for unsupported static openssl build... " >&6; }
++  new_OPENSSL_LIBS=
++  for arg in $OPENSSL_LIBS; do
++    case $arg in #(
++  -l*) :
++
++        libname=$(echo $arg | cut -c3-)
++        case `uname` in
++          Linux)
++        new_OPENSSL_LIBS="$new_OPENSSL_LIBS -l:lib${libname}.a -Wl,--exclude-libs,lib${libname}.a"
++            ;;
++          Darwin)
++            new_OPENSSL_LIBS="$new_OPENSSL_LIBS -Wl,-hidden-l${libname}"
++            ;;
++        esac
++       ;; #(
++  *) :
++    new_OPENSSL_LIBS="$new_OPENSSL_LIBS $arg"
++     ;;
++esac
++  done
++    OPENSSL_LIBS="$new_OPENSSL_LIBS $ZLIB_LIBS"
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENSSL_LIBS" >&5
++$as_echo "$OPENSSL_LIBS" >&6; }
++
++fi
++
++LIBCRYPTO_LIBS=
++for arg in $OPENSSL_LIBS; do
++  case $arg in #(
++  -l*ssl*|-Wl*ssl*) :
++     ;; #(
++  *) :
++    LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS $arg"
++   ;;
++esac
++done
++
+ # check if OpenSSL libraries work as expected
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL provides required APIs" >&5
+ $as_echo_n "checking whether OpenSSL provides required APIs... " >&6; }

--- a/patches/python-3.10-setup.py.patch
+++ b/patches/python-3.10-setup.py.patch
@@ -1,5 +1,5 @@
 --- setup.py.orig	2022-12-06 19:31:21.000000000 +0100
-+++ setup.py	2022-12-16 13:14:39.256469721 +0100
++++ setup.py	2022-12-16 15:34:27.000000000 +0100
 @@ -2272,7 +2272,8 @@
                                 libraries=['m']))
  
@@ -10,3 +10,15 @@
  
          ffi_inc_dirs = self.inc_dirs.copy()
          if MACOS:
+@@ -2488,6 +2489,11 @@
+         # Only tested on GCC and clang on X86_64.
+         if os.environ.get("PY_UNSUPPORTED_OPENSSL_BUILD") == "static":
+             extra_linker_args = []
++            if MACOS:
++                openssl_libs = split_var('OPENSSL_LIBS', '-Wl,')
++                for lib in openssl_libs:
++                  extra_linker_args.append(f"-Wl,{lib}")
++            else:
+             for lib in openssl_extension_kwargs["libraries"]:
+                 # link statically
+                 extra_linker_args.append(f"-l:lib{lib}.a")

--- a/patches/python-3.10-setup.py.patch
+++ b/patches/python-3.10-setup.py.patch
@@ -1,5 +1,5 @@
 --- setup.py.orig	2022-12-06 19:31:21.000000000 +0100
-+++ setup.py	2022-12-16 15:46:54.000000000 +0100
++++ setup.py	2022-12-16 16:13:35.000000000 +0100
 @@ -2272,7 +2272,8 @@
                                 libraries=['m']))
  
@@ -10,25 +10,19 @@
  
          ffi_inc_dirs = self.inc_dirs.copy()
          if MACOS:
-@@ -2488,11 +2489,16 @@
+@@ -2487,12 +2488,10 @@
+         # features like DSO engines or external OSSL providers don't work.
          # Only tested on GCC and clang on X86_64.
          if os.environ.get("PY_UNSUPPORTED_OPENSSL_BUILD") == "static":
++            openssl_libs = split_var('OPENSSL_LIBS', '')
              extra_linker_args = []
 -            for lib in openssl_extension_kwargs["libraries"]:
 -                # link statically
 -                extra_linker_args.append(f"-l:lib{lib}.a")
 -                # don't export symbols
 -                extra_linker_args.append(f"-Wl,--exclude-libs,lib{lib}.a")
-+            if MACOS:
-+                openssl_libs = split_var('OPENSSL_LIBS', '-Wl,')
-+                for lib in openssl_libs:
-+                  extra_linker_args.append(f"-Wl,{lib}")
-+            else:
-+                for lib in openssl_extension_kwargs["libraries"]:
-+                    # link statically
-+                    extra_linker_args.append(f"-l:lib{lib}.a")
-+                    # don't export symbols
-+                    extra_linker_args.append(f"-Wl,--exclude-libs,lib{lib}.a")
++            for lib in openssl_libs:
++                extra_linker_args.append(lib)
              openssl_extension_kwargs["extra_link_args"] = extra_linker_args
              # don't link OpenSSL shared libraries.
              # include libz for OpenSSL build flavors with compression support

--- a/patches/python-3.10-setup.py.patch
+++ b/patches/python-3.10-setup.py.patch
@@ -1,0 +1,12 @@
+--- setup.py.orig	2022-12-06 19:31:21.000000000 +0100
++++ setup.py	2022-12-16 13:14:39.256469721 +0100
+@@ -2272,7 +2272,8 @@
+                                libraries=['m']))
+ 
+         ffi_inc = sysconfig.get_config_var("LIBFFI_INCLUDEDIR")
+-        ffi_lib = None
++        ffi_lib = ":libffi_pic.a"
++        extra_link_args.append('--exclude-libs,libffi_pic.a')
+ 
+         ffi_inc_dirs = self.inc_dirs.copy()
+         if MACOS:

--- a/patches/python-3.10-setup.py.patch
+++ b/patches/python-3.10-setup.py.patch
@@ -1,5 +1,5 @@
 --- setup.py.orig	2022-12-06 19:31:21.000000000 +0100
-+++ setup.py	2022-12-16 15:34:27.000000000 +0100
++++ setup.py	2022-12-16 15:46:54.000000000 +0100
 @@ -2272,7 +2272,8 @@
                                 libraries=['m']))
  
@@ -10,15 +10,25 @@
  
          ffi_inc_dirs = self.inc_dirs.copy()
          if MACOS:
-@@ -2488,6 +2489,11 @@
+@@ -2488,11 +2489,16 @@
          # Only tested on GCC and clang on X86_64.
          if os.environ.get("PY_UNSUPPORTED_OPENSSL_BUILD") == "static":
              extra_linker_args = []
+-            for lib in openssl_extension_kwargs["libraries"]:
+-                # link statically
+-                extra_linker_args.append(f"-l:lib{lib}.a")
+-                # don't export symbols
+-                extra_linker_args.append(f"-Wl,--exclude-libs,lib{lib}.a")
 +            if MACOS:
 +                openssl_libs = split_var('OPENSSL_LIBS', '-Wl,')
 +                for lib in openssl_libs:
 +                  extra_linker_args.append(f"-Wl,{lib}")
 +            else:
-             for lib in openssl_extension_kwargs["libraries"]:
-                 # link statically
-                 extra_linker_args.append(f"-l:lib{lib}.a")
++                for lib in openssl_extension_kwargs["libraries"]:
++                    # link statically
++                    extra_linker_args.append(f"-l:lib{lib}.a")
++                    # don't export symbols
++                    extra_linker_args.append(f"-Wl,--exclude-libs,lib{lib}.a")
+             openssl_extension_kwargs["extra_link_args"] = extra_linker_args
+             # don't link OpenSSL shared libraries.
+             # include libz for OpenSSL build flavors with compression support

--- a/scripts/pympip
+++ b/scripts/pympip
@@ -9,7 +9,15 @@ const bin_dir = path.resolve(path.dirname(
 const exe = os.platform() === 'win32' ? 'python.exe' : path.join('bin', 'python3');
 const python = path.join(bin_dir, exe);
 if (fs.existsSync(python)) {
-  cp.spawnSync(python, ['-m', 'pip', ...process.argv.slice(2)], { stdio: 'inherit', env: { PYTHONHOME: bin_dir } });
+  console.log(bin_dir);
+  cp.spawnSync(python, ['-m', 'pip', ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      PYTHONHOME: bin_dir,
+      CFLAGS: (process.env.CFLAGS || '') + ` -I${bin_dir}/include/python3.11`
+    }
+  });
 } else {
   console.error('You don\'t appear to have the pymport built-in Python environment installed: ',
     python);

--- a/scripts/pympip
+++ b/scripts/pympip
@@ -15,7 +15,7 @@ if (fs.existsSync(python)) {
     env: {
       ...process.env,
       PYTHONHOME: bin_dir,
-      CFLAGS: (process.env.CFLAGS || '') + ` -I${bin_dir}/include/python3.11`
+      CFLAGS: (process.env.CFLAGS || '') + ` -I${bin_dir}/include/python3.10`
     }
   });
 } else {

--- a/test/pymport.test.ts
+++ b/test/pymport.test.ts
@@ -16,8 +16,8 @@ describe('pymport', () => {
     if (version.pythonLibrary.builtin) {
       assert.isString(version.pythonHome);
       assert.strictEqual(version.pythonLibrary.major, 3);
-      assert.strictEqual(version.pythonLibrary.minor, 11);
-      assert.strictEqual(version.pythonLibrary.micro, 1);
+      assert.strictEqual(version.pythonLibrary.minor, 10);
+      assert.strictEqual(version.pythonLibrary.micro, 9);
       assert.strictEqual(version.pythonLibrary.release, 15);
       assert.strictEqual(version.pythonLibrary.serial, 0);
       assert.isString(version.pythonLibrary.version);

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 pandas
-xxhash

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 pandas
+xxhash


### PR DESCRIPTION
Fixes #40, various issues related to the new `setuptools`
Backport the static SSL patches to 3.9