### PR TITLE
do not consider attributes with falsy values as being undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.3.1] WIP
+ - Fix [#48](https://github.com/mmomtchev/pymport/issues/48), do not consider falsy properties as being undefined
+
 ## [1.3.0] 2022-12-22
 
 #### New Features

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ const proxy = {
     let r;
     // attr is the Python attribute of the underlying Python object
     const attr = target.get(prop);
-    if (attr === undefined && target[prop]) {
+    if (attr === undefined && target[prop] !== undefined) {
       // there is no underlying Python attribute of this name
       // but there is a PyObject method
       if (typeof target[prop] === 'function') {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -184,6 +184,12 @@ describe('proxy', () => {
       }
       assert.deepEqual(result, [8, 9, 3]);
     });
+
+    it('empty', () => {
+      const list = PyObject.list([]);
+      assert.strictEqual(list.type, 'list');
+      assert.strictEqual(list.length, 0);
+    });
   });
 
   describe('dict', () => {
@@ -197,6 +203,12 @@ describe('proxy', () => {
         result.push(el.toJS());
       }
       assert.deepEqual(result, ['a', 'b', 'c']);
+    });
+
+    it('empty', () => {
+      const t = PyObject.tuple([]);
+      assert.strictEqual(t.type, 'tuple');
+      assert.strictEqual(t.length, 0);
     });
   });
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -203,6 +203,12 @@ describe('types', () => {
       assert.deepEqual(list.toJS(), ['a', 'b', 'c', 'd']);
     });
 
+    it('empty', () => {
+      const list = PyObject.list([]);
+      assert.strictEqual(list.type, 'list');
+      assert.strictEqual(list.length, 0);
+    });
+
     it('append()', () => {
       const a = PyObject.list([1]);
       assert.lengthOf(a, 1);
@@ -327,6 +333,12 @@ describe('types', () => {
       assert.throws(() => t.item(10));
       assert.throws(() => PyObject.keys(t), /'tuple' object has no attribute 'keys'/);
       assert.throws(() => PyObject.values(t), /'tuple' object has no attribute 'values'/);
+    });
+
+    it('empty', () => {
+      const t = PyObject.tuple([]);
+      assert.strictEqual(t.type, 'tuple');
+      assert.strictEqual(t.length, 0);
     });
 
     it('tuple() from PyObject iterable', () => {


### PR DESCRIPTION
Fixes #48 