### PR TITLE
`item()` returns `undefined` on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Allow disabling of the generic Buffer protocol transformation to `toJS()`
  - Add `PyObject.prototype.map` method compatible with `Array.prototype.map`
  - Proxified functions are now also `Proxy` objects, resolves [#58](https://github.com/mmomtchev/pymport/issues/58)
+ - `PyObject.item()` now returns `undefined` instead of throwing an exception when an element cannot be retrieved by `[]`
 
-#### Bug Fixes
+##### Bug Fixes
  - Fix [#66](https://github.com/mmomtchev/pymport/issues/66), race condition can result in an abort when using `pymport` with `worker_threads`
-
-### [1.3.2] WIP
-
  - Fix [#40](https://github.com/mmomtchev/pymport/issues/40), patch `_sysconfigdata` after installation
 
 ### [1.3.1] 2023-01-07

--- a/src/pyobj.cc
+++ b/src/pyobj.cc
@@ -165,7 +165,10 @@ Value PyObjectWrap::Item(const CallbackInfo &info) {
   if (info.Length() < 1) throw Error::New(env, "Missing mandatory argument");
   PyStrongRef item = FromJS(info[0]);
   PyStrongRef r = PyObject_GetItem(*self, *item);
-  EXCEPTION_CHECK(env, r);
+  if (r == nullptr) {
+    PyErr_Clear();
+    return env.Undefined();
+  }
   return New(env, std::move(r));
 }
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -21,7 +21,7 @@ describe('types', () => {
       assert.instanceOf(f, PyObject);
       assert.isFalse(f.callable);
       assert.isUndefined(f.length);
-      assert.throws(() => f.item(0), /not subscriptable/);
+      assert.isUndefined(f.item(0));
       assert.throws(() => PyObject.keys(f), /does not support mapping/);
       assert.throws(() => PyObject.values(f), /does not support mapping/);
       assert.equal(f.type, 'float');
@@ -85,7 +85,7 @@ describe('types', () => {
       assert.instanceOf(f, PyObject);
       assert.isFalse(f.callable);
       assert.isUndefined(f.length);
-      assert.throws(() => f.item(0), /not subscriptable/);
+      assert.isUndefined(f.item(0));
       assert.throws(() => PyObject.keys(f), /does not support mapping/);
       assert.throws(() => PyObject.values(f), /does not support mapping/);
       assert.equal(f.type, 'int');
@@ -197,7 +197,7 @@ describe('types', () => {
       assert.equal(a.type, 'list');
       assert.equal(a.length, 3);
       assert.equal(a.item(1).toJS(), 2.1);
-      assert.throws(() => a.item(10));
+      assert.isUndefined(a.item(10));
       assert.throws(() => PyObject.keys(a), /'list' object has no attribute 'keys'/);
       assert.throws(() => PyObject.values(a), /'list' object has no attribute 'values'/);
       assert.deepEqual(a.toJS(), array);
@@ -274,7 +274,7 @@ describe('types', () => {
       const set = PyObject.set(array);
       assert.equal(set.type, 'set');
       assert.equal(set.length, 3);
-      assert.throws(() => set.item(1), /'set' object is not subscriptable/);
+      assert.isUndefined(set.item(1));
       assert.throws(() => PyObject.keys(set), /Object does not support mapping protocol/);
       assert.throws(() => PyObject.values(set), /Object does not support mapping protocol/);
       assert.isTrue(set.get('__contains__').call(2).toJS());
@@ -359,7 +359,7 @@ describe('types', () => {
       assert.isFalse(t.callable);
       assert.equal(t.length, 3);
       assert.equal(t.item(1).toJS(), 'a');
-      assert.throws(() => t.item(10));
+      assert.isUndefined(t.item(10));
       assert.throws(() => PyObject.keys(t), /'tuple' object has no attribute 'keys'/);
       assert.throws(() => PyObject.values(t), /'tuple' object has no attribute 'values'/);
     });


### PR DESCRIPTION
Implements #56 