### PR TITLE
use `fvisibility=hidden` on POSIX platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.4.3]
+ - Fix [#104](https://github.com/mmomtchev/pymport/issues/104), do not mess up the loading of additional binary modules after `pymport`
+
 ### [1.4.2] 2023-08-28
  - Builtin Python updated to 3.10.13
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -99,6 +99,7 @@
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
             'OTHER_CPLUSPLUSFLAGS': [ '-std=c++14' ]
           },
+          'cflags': [ '-fvisibility=hidden '],
           'cflags_cc': [ '-std=c++14' ],
           'cflags!': [ '-fno-exceptions' ],
           'cflags_cc!': [ '-fno-exceptions' ],

--- a/src/main.cc
+++ b/src/main.cc
@@ -110,7 +110,7 @@ static void InitDebug() {
 }
 #endif
 
-Napi::Object Init(Env env, Object exports) {
+Napi::Object Pymp_Init(Env env, Object exports) {
 #ifdef DEBUG
   InitDebug();
 #endif
@@ -223,4 +223,4 @@ Napi::Object Init(Env env, Object exports) {
   return exports;
 }
 
-NODE_API_MODULE(pymport, Init)
+NODE_API_MODULE(pymport, Pymp_Init)

--- a/src/main.cc
+++ b/src/main.cc
@@ -110,7 +110,7 @@ static void InitDebug() {
 }
 #endif
 
-Napi::Object Pymp_Init(Env env, Object exports) {
+static Napi::Object PympInit(Env env, Object exports) {
 #ifdef DEBUG
   InitDebug();
 #endif
@@ -223,4 +223,4 @@ Napi::Object Pymp_Init(Env env, Object exports) {
   return exports;
 }
 
-NODE_API_MODULE(pymport, Pymp_Init)
+NODE_API_MODULE(pymport, PympInit)


### PR DESCRIPTION
On POSIX `pymport` is loaded with `RTLD_GLOBAL` to export the Python interpreter to the eventual Python binary modules.

This can lead to symbol conflicts with other binary modules.

Fixes: #104 