### PR TITLE
compatibility with `node_api_nogc_env` in Node.js 18.20

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-20.04, ubuntu-22.04, macos-11, windows-2019]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 21.x]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - node-version: 16.x

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -22,7 +22,7 @@ jobs:
           - windows-2022
           - macos-11
           - macos-12
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 21.x]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,7 +1,6 @@
 {
   "env": {
     "projectDefines": [
-      "NAPI_EXPERIMENTAL",
       "NODE_ADDON_API_DISABLE_DEPRECATED",
       "NAPI_VERSION=8",
       "PYMPORT_VERSION_MAJOR=1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.5.1] 2024-04-01
+ - Fix the build with recent Node.js versions after `node_api_nogc_env` in Node.js 18.20
+
 ## [1.5.0] 2024-02-08
  - Add Python 3.12 support and upgrade the built-in Python to 3.12.2
  - Drop Node.js 14 support

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,7 +23,6 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       'defines': [
-        'NAPI_EXPERIMENTAL',
         'NODE_ADDON_API_DISABLE_DEPRECATED',
         'NAPI_VERSION=8',
         'PYMPORT_VERSION_MAJOR=<!(node -e "console.log(require(\'./package.json\').version.split(\'.\')[0])")',

--- a/src/pymport.h
+++ b/src/pymport.h
@@ -1,5 +1,4 @@
 #pragma once
-#define NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT
 
 #include <map>
 #include <list>

--- a/src/pymport.h
+++ b/src/pymport.h
@@ -1,4 +1,5 @@
 #pragma once
+#define NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT
 
 #include <map>
 #include <list>


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v18.20.0